### PR TITLE
Improve visualization when mic is muted or sender is disconnected

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -125,6 +125,9 @@
                     if (event.data === 'mic_active' || event.data === 'mic_muted') {
                         micStatus = event.data;
                         updateStatusMessage();
+                        if (micStatus === 'mic_muted') {
+                            resetVisualizer();
+                        }
                     }
                 } else if (event.data instanceof ArrayBuffer) {
                     if (micStatus === 'mic_muted') return;
@@ -164,6 +167,7 @@
             statusMessage.textContent = 'Click to start audio';
             statusMessage.className = '';
             updateStatusMessage();
+            resetVisualizer();
         }
 
         function updateStatusMessage() {
@@ -217,6 +221,11 @@
 
         function updateVisualizer(newData) {
             visualizerData = new Float32Array([...visualizerData.slice(newData.length), ...newData]);
+            drawWaveform();
+        }
+
+        function resetVisualizer() {
+            visualizerData.fill(0);
             drawWaveform();
         }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -234,6 +234,7 @@ class _StreamingControlState extends State<StreamingControl> {
         _startStreaming();
       } else {
         _stopStreaming();
+        _audioSamples = []; // Reset visualizer data to zero level
       }
       if (_bitrateChangeNotification) {
         _streamingService.setBitrate(_selectedBitrate);
@@ -264,7 +265,10 @@ class _StreamingControlState extends State<StreamingControl> {
                 children: [
                   CustomPaint(
                     size: Size(200, 200),
-                    painter: CircularWaveformPainter(samples: _audioSamples),
+                    painter: CircularWaveformPainter(
+                      samples: _audioSamples,
+                      isMicMuted: !_isStreaming, // Pass the mic status
+                    ),
                   ),
                   StreamBuilder<double>(
                     stream: _streamingService.micLevelStream,
@@ -429,16 +433,18 @@ class CircularWaveformPainter extends CustomPainter {
   final List<int> samples;
   final Color color;
   final double strokeWidth;
+  final bool isMicMuted;
 
   CircularWaveformPainter({
     required this.samples,
     this.color = Colors.blueAccent,
     this.strokeWidth = 2.0,
+    required this.isMicMuted,
   });
 
   @override
   void paint(Canvas canvas, Size size) {
-    if (samples.isEmpty) return;
+    if (isMicMuted || samples.isEmpty) return; // Stop drawing when mic is muted
 
     final center = Offset(size.width / 2, size.height / 2);
     final radius = min(center.dx, center.dy);


### PR DESCRIPTION
Update `assets/www/index.html` to reset visualizer when mic is muted or disconnected.

* **WebSocket Message Handling**
  - Add condition to reset visualizer when mic is muted.
  - Reset visualizer when stop button is clicked.

* **Visualizer Functions**
  - Add `resetVisualizer` function to reset visualizer data to zero level.
  - Update `updateVisualizer` function to call `resetVisualizer` when necessary.

Update `lib/main.dart` to stop drawing waveform when mic is muted.

* **CircularWaveformPainter**
  - Add `isMicMuted` parameter to control drawing.
  - Stop drawing waveform when mic is muted.

* **_toggleStreaming**
  - Reset visualizer data to zero level when sender is muted or disconnected.

