### PR TITLE
Add latency display to the app

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -128,6 +128,8 @@
                         if (micStatus === 'mic_muted') {
                             resetVisualizer();
                         }
+                    } else if (event.data.startsWith('time:')) { // P69c7
+                        webSocket.send(event.data); // P69c7
                     }
                 } else if (event.data instanceof ArrayBuffer) {
                     if (micStatus === 'mic_muted') return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,6 +53,7 @@ class _StreamingControlState extends State<StreamingControl> {
   int _selectedBitrate = 64; // Default bitrate
   bool _bitrateChangeNotification = false;
   List<int> _audioSamples = [];
+  double _latency = 0.0; // P503b
 
   static const platform = MethodChannel('com.jorin.audio_live_stream/hostname');
 
@@ -95,6 +96,12 @@ class _StreamingControlState extends State<StreamingControl> {
       });
       print('Anzahl verbundener Clients aktualisiert: $_connectedClients');
     };
+
+    _streamingService.webServer.latencyStream.listen((latency) { // P0225
+      setState(() {
+        _latency = latency;
+      });
+    });
   }
 
   Future<void> _initializeStreaming() async {
@@ -312,10 +319,11 @@ class _StreamingControlState extends State<StreamingControl> {
             style: const TextStyle(color: Colors.grey),
           ),
           const Spacer(),
-          // BitrateSlider(
-          //   initialBitrate: _selectedBitrate,
-          //   onBitrateChanged: _onBitrateChanged,
-          // ),
+          Text( // P49f4
+            'Average Latency: ${_latency.toStringAsFixed(2)} ms',
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: Colors.grey),
+          ),
           const SizedBox(height: 20),
           _serverStarting
               ? const Center(


### PR DESCRIPTION
Add average latency display in the app.

* Add a `latency` variable to `_StreamingControlState` in `lib/main.dart` to store the average latency.
* Add a `latencyStream` to `WebServer` in `lib/main.dart` to listen for latency updates.
* Display the `latency` value in the UI between the mic button and the server address in `lib/main.dart`.
* Add a `latencyStreamController` to broadcast latency updates in `lib/web_server.dart`.
* Add a method to send a timestamp message to all connected clients every second in `lib/web_server.dart`.
* Add a method to handle timestamp messages from clients and calculate the average latency in `lib/web_server.dart`.
* Add a getter for `latencyStream` to expose the latency updates in `lib/web_server.dart`.
* Add a handler for the timestamp message to send it back to the server immediately in `assets/www/index.html`.

